### PR TITLE
fix: ensure default user agent fallback

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -21,7 +21,7 @@ const userAgents = {
 };
 // Set a global custom user agent for the entire app
 if (config.userAgentString !== "honest") {
-  app.userAgentFallback = userAgents[config.userAgentString] || userAgents.default;
+  app.userAgentFallback = userAgents[config.userAgentString] || userAgents.chrome;
 };
 
 let mainWindow;


### PR DESCRIPTION
## Summary
- default to Chrome user agent when an unknown string is supplied

## Testing
- `node --check src/main/index.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_689079bbd5a4832eaed5fd96179ab3bb