### PR TITLE
Fix overridden variable typo

### DIFF
--- a/resources/custom.js
+++ b/resources/custom.js
@@ -307,24 +307,24 @@ function runBlockYoutube() {
             if (!obj) {
                 return false;
             }
-            let overriden = false;
+            let overridden = false;
 
             for (const key in obj) {
                 if (obj.hasOwnProperty(key) && key === propertyName) {
                     obj[key] = overrideValue;
-                    overriden = true;
+                    overridden = true;
                 } else if (obj.hasOwnProperty(key) && typeof obj[key] === 'object') {
                     if (overrideObject(obj[key], propertyName, overrideValue)) {
-                        overriden = true;
+                        overridden = true;
                     }
                 }
             }
 
-            if (overriden) {
+            if (overridden) {
                 console.log(`found: ${propertyName}`);
             }
 
-            return overriden;
+            return overridden;
         };
 
         /**


### PR DESCRIPTION
## Summary
- correct misspelled `overriden` flag to `overridden`

## Testing
- `git ls-files | grep -v resources/easylist.txt | xargs codespell -L ist,Sie,comando`

------
https://chatgpt.com/codex/tasks/task_e_6890ba253fc8832eb48b181aed1ceb41